### PR TITLE
Allow usage with any 0.4 cqrs-es version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sqlite-es"
 readme = "README.md"
 
 [dependencies]
-cqrs-es = "0.4.9"
+cqrs-es = "~0.4"
 
 async-trait = "0.1"
 futures = "0.3"


### PR DESCRIPTION
This commit changes the dependency constraint of cqrs-es to Tilde: any 0.4 version for cqrs-es will do.
This presumes that within the 0.4.x range, cqrs-es will keep its persistance trait stable. We don't know for certain if this is the case.

The tests pass against the latest 0.4.10 version.